### PR TITLE
Used the current python executing the worker.py to spawn subprocess.

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,9 +9,11 @@ from uuid import uuid4
 
 from tornado import websocket, web, ioloop
 
+
 class IndexHandler(web.RequestHandler):
     def get(self):
         self.render("index.html")
+
 
 class SocketHandler(websocket.WebSocketHandler):
     def check_origin(self, origin):
@@ -33,27 +35,26 @@ class SocketHandler(websocket.WebSocketHandler):
         """
         self.application.pc.unregister_websocket(self._get_sess_id())
 
+
 class Connect(web.RequestHandler):
 
     @web.asynchronous
     def get(self, *args):
-        with open('connector.html') as fh:
-            self.write(fh.read())
-            self.finish()
+        self.render('connector.html')
+
 
 class Index(web.RequestHandler):
 
     @web.asynchronous
     def get(self, *args):
-        with open('index.html') as fh:
-            self.write(fh.read())
-            self.finish()
+        self.render('index.html')
 
 app = web.Application([
     (r'/ws', SocketHandler),
     (r'/connect', Connect),
     (r'/', Index),
 ])
+
 
 def runserver():
     my_ioloop = ioloop.IOLoop.instance()

--- a/worker.py
+++ b/worker.py
@@ -74,7 +74,7 @@ def manage_processes():
     no_subprocess = [arg.split('manage=')[-1] for arg in sys.argv if 'manage' in arg][0]
     print("starting %s workers" % no_subprocess)
     for i in range(int(no_subprocess)):
-        proc = subprocess.Popen(["python", "worker.py"],
+        proc = subprocess.Popen([sys.executable, __file__],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         child_pids.append(proc.pid)


### PR DESCRIPTION
Also passed to the subprocess.Popen the **file** reference instead
of "worker.py" so we can make shure the script we're spanning
suprocesses is the same file we're running originally.

Fixes: #1
